### PR TITLE
Add mechanism for debug printing from inside the active extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## CHANGELOG: bga-wingspan-scraper
 
-### Firefox extension to scrape data from a Wingspan game replay on Board Game Arena 
+### Firefox extension to scrape data from a Wingspan game replay on Board Game Arena
 
 All notable changes to this project will be documented in this file.
 
@@ -10,9 +10,7 @@ This project follows a `yyyy.mm.dd.n` flavor of
 [Calendar Versioning](https://calver.org/). The `n` value is sequential and
 serves to distinguish between multiple releases created on the same day.
 
-
-### *Unreleased*
-
+### _Unreleased_
 
 #### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+## CHANGELOG: bga-wingspan-scraper
+
+### Firefox extension to scrape data from a Wingspan game replay on Board Game Arena 
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+This project follows a `yyyy.mm.dd.n` flavor of
+[Calendar Versioning](https://calver.org/). The `n` value is sequential and
+serves to distinguish between multiple releases created on the same day.
+
+
+### *Unreleased*
+
+
+#### Features
+
+- TypeScript codebase, webpacked, manifested, and zipped. Builds to a
+  single-file artifact ready to be loaded into Firefox's 'Load Temporary Add-on'
+  feature.
+
+- Set up to scrape each player's score at the end of each 'turnset' (at the
+  point when the active turn returns to the player with the first-turn token
+  that round).
+
+- Automatically advances the replay through the game history in order to put the
+  page into the state needed to accurately scrape the scores.
+
+- Includes a UI for debugging during development, lightweight consistency
+  checking of key data for a given replay, and kickoff of the score-scraping
+  process.

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -39,23 +39,25 @@ const addDebugControls = (dropdown: HTMLSelectElement) => {
     const commandArgStrs = inputDebugEval.value.split(',')
 
     // @ts-ignore
-    const commandArgVals = commandArgStrs.map(arg => eval(arg))
+    const commandArgVals = commandArgStrs.map((arg) => eval(arg))
 
-    const evaluator = (func: () => any) => {return func()}
+    const evaluator = (func: () => any) => {
+      return func()
+    }
 
     // TODO: Refactor this switch for func creation to a new file.
     //  No need to bloat this one.
-    switch(dropdown.value) {
+    switch (dropdown.value) {
       case GET_RAW_MOVE_INFO:
         func = () => getRawMoveInfo()
         break
 
       case RAW_MOVE_ID_LIST:
-        func = () => getRawMoveInfo().map(rm => parseInt(rm.moveNum))
+        func = () => getRawMoveInfo().map((rm) => parseInt(rm.moveNum))
         break
 
       default:
-        func = () => "Not Implemented"
+        func = () => 'Not Implemented'
     }
 
     try {
@@ -138,7 +140,7 @@ const addDropDownRunFunction = (): HTMLSelectElement => {
   dropdownRunFunction.style.width = '15em'
   dropdownRunFunction.style.paddingLeft = '0.5em'
 
-  OPTIONS.forEach(opText => {
+  OPTIONS.forEach((opText) => {
     var option = document.createElement('option')
     option.textContent = opText
     dropdownRunFunction.appendChild(option)
@@ -174,5 +176,4 @@ export const buildUI = () => {
   addButtonScrapeScores()
   const dropdown = addDropDownRunFunction()
   addDebugControls(dropdown)
-  
 }

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -1,8 +1,14 @@
 import { checkFullPlaySequence, checkMoveListLength } from '@/checks/moves'
+import { getRawMoveInfo } from '@/data/moves'
 import { sleepHelper } from '@/helpers/async'
 import { scrapeAndSave } from '@/scrape/scores'
 
-const addDebugControls = () => {
+const GET_RAW_MOVE_INFO = 'getRawMoveInfo()'
+const RAW_MOVE_ID_LIST = 'Raw Move ID List'
+
+const OPTIONS = [GET_RAW_MOVE_INFO, RAW_MOVE_ID_LIST]
+
+const addDebugControls = (dropdown: HTMLSelectElement) => {
   // Button to trigger debug eval
   // These controls may be obsolete, since it's hard to reach into the
   // webpack this way
@@ -29,8 +35,31 @@ const addDebugControls = () => {
 
   // Evalaute the expression in the input box when the button is clicked
   buttonDebugPrint.addEventListener('click', () => {
+    var func: () => any
+    const commandArgStrs = inputDebugEval.value.split(',')
+
+    // @ts-ignore
+    const commandArgVals = commandArgStrs.map(arg => eval(arg))
+
+    const evaluator = (func: () => any) => {return func()}
+
+    // TODO: Refactor this switch for func creation to a new file.
+    //  No need to bloat this one.
+    switch(dropdown.value) {
+      case GET_RAW_MOVE_INFO:
+        func = () => getRawMoveInfo()
+        break
+
+      case RAW_MOVE_ID_LIST:
+        func = () => getRawMoveInfo().map(rm => parseInt(rm.moveNum))
+        break
+
+      default:
+        func = () => "Not Implemented"
+    }
+
     try {
-      const result = eval(inputDebugEval.value)
+      const result = evaluator(func)
       alert(JSON.stringify(result))
     } catch (err) {
       alert(`Error: ${(err as Error).message}`)
@@ -97,6 +126,29 @@ const addButtonCheckMoveList = () => {
   document.body.appendChild(buttonCheckMoveList)
 }
 
+const addDropDownRunFunction = (): HTMLSelectElement => {
+  // Dropdown for selecting which function to run
+  // Pulls arguments from inputDebugEval
+  const dropdownRunFunction = document.createElement('select')
+  dropdownRunFunction.id = 'dropdownRunFunction'
+  dropdownRunFunction.style.position = 'fixed'
+  dropdownRunFunction.style.top = '90%'
+  dropdownRunFunction.style.left = '26em'
+  dropdownRunFunction.style.height = '2.25em'
+  dropdownRunFunction.style.width = '15em'
+  dropdownRunFunction.style.paddingLeft = '0.5em'
+
+  OPTIONS.forEach(opText => {
+    var option = document.createElement('option')
+    option.textContent = opText
+    dropdownRunFunction.appendChild(option)
+  })
+
+  document.body.appendChild(dropdownRunFunction)
+
+  return dropdownRunFunction
+}
+
 const addButtonAwaitTest = () => {
   // Button for testing await behavior
   const buttonAwaitTest = document.createElement('button')
@@ -120,5 +172,7 @@ export const buildUI = () => {
   addButtonCheckMoveList()
   addButtonCheckPlaySeq()
   addButtonScrapeScores()
-  addDebugControls()
+  const dropdown = addDropDownRunFunction()
+  addDebugControls(dropdown)
+  
 }


### PR DESCRIPTION
Closes #56.

This is going to be less flexible than I would prefer, but since we're working with compiled & Webpacked TypeScript, just using `eval(...)` isn't going to work -- we have to import the functions to be called via TypeScript mechanisms, and then call them outright, without `eval()`.

It should be possible to pull arguments from the debug `<input>`. For any given function, we'll know how many arguments we need, so we just pull that many from the `.split(',')` args list and ignore the rest.

If there gets to be too many debug commands, then probably going one level deep in a hierarchy of `<select>` elements will be called for. A top-level selector that then exposes a set of low-level selectors. Hopefully it'll be awhile before we get to that point...........